### PR TITLE
feat/aws-vpce: add support to endpoint service interface type

### DIFF
--- a/tasks/aws-vpc.yml
+++ b/tasks/aws-vpc.yml
@@ -74,6 +74,11 @@
 - name: AWS | VPC Routing
   include_tasks: aws-routing.yml
 
+- name: AWS | VPC Security Groups
+  include_tasks: aws-sg.yml
+  when: item_vpc.security_groups is defined
+  tags: sg
+
 - name: AWS | VPC endpoint services
   include_tasks: aws-vpce-service.yml
   when: item_vpc.endpoint_services is defined
@@ -81,11 +86,6 @@
   loop_control:
     loop_var: item_vpces
   tags: vpce
-
-- name: AWS | VPC Security Groups
-  include_tasks: aws-sg.yml
-  when: item_vpc.security_groups is defined
-  tags: sg
 
 - name: VPC | Update Global states
   set_fact:

--- a/tasks/aws-vpce-service.yml
+++ b/tasks/aws-vpce-service.yml
@@ -1,27 +1,35 @@
 ---
-- name: AWS | VPCe Services | Init vars
-  set_fact:
-    vpces_rtb_ids: []
-  tags: always
-
-- name: AWS | VPCe Services | Filter Route Tables
-  ec2_vpc_route_table_info:
-    region: "{{ item_vpc.region }}"
-    filters:
-      "tag:Name": "{{ item_rtb }}"
-  register: rtbs
-  with_items: "{{ item_vpces.route_tables }}"
-  loop_control:
-    loop_var: item_rtb
-
-- name: AWS | VPCe Services | Mount Rtb IDs
-  set_fact:
-    vpces_rtb_ids: "{{ vpces_rtb_ids + [item.route_tables[0].id] }}"
-  with_items: "{{ rtbs.results }}"
-
-- name: AWS | VPCe Services | Show table IDS
+- name: AWS | VPCe Services | Init
   debug:
-    var: vpces_rtb_ids
+    msg: "Endpoint service name: {{ item_vpces.service }}"
+
+- name: AWS | VPCe Services | Lookup Route tables
+  block:
+
+  - name: AWS | VPCe Services | Init vars
+    set_fact:
+      vpces_rtb_ids: []
+
+  - name: AWS | VPCe Services | Filter Route Tables
+    ec2_vpc_route_table_info:
+      region: "{{ item_vpc.region }}"
+      filters:
+        "tag:Name": "{{ item_rtb }}"
+    register: rtbs
+    with_items: "{{ item_vpces.route_tables | d([]) }}"
+    loop_control:
+      loop_var: item_rtb
+
+  - name: AWS | VPCe Services | Mount Rtb IDs
+    set_fact:
+      vpces_rtb_ids: "{{ vpces_rtb_ids + [item.route_tables[0].id] }}"
+    with_items: "{{ rtbs.results }}"
+
+  - name: AWS | VPCe Services | Show table IDS
+    debug:
+      var: vpces_rtb_ids
+
+  when: item_vpces.route_tables | d([]) | length > 0
 
 - name: AWS | VPCe Services | Create
   ec2_vpc_endpoint:
@@ -29,7 +37,13 @@
     region: "{{ item_vpc.region }}"
     vpc_id: "{{ vpc_id }}"
     service: "{{ item_vpces.service }}"
-    route_table_ids: "{{ vpces_rtb_ids }}"
+    route_table_ids: "{{ vpces_rtb_ids | d(omit) }}"
+    vpc_endpoint_security_groups: "{{ item_vpces.security_groups | d(omit) }}"
+    vpc_endpoint_subnets: "{{ item_vpces.subnets | d(omit) }}"
+    vpc_endpoint_type: "{{ item_vpces.type | d('Gateway') }}"
+    validate_certs: "{{ item_vpces.validate_certs | d(omit) }}"
+    policy_file: "{{ item_vpces.policy_file | d(omit) }}"
+    policy: "{{ item_vpces.policy | d(omit) }}"
     tags:
       Name: "{{ item_vpces.name }}"
   register: new_vpc_endpoint

--- a/tasks/aws-vpce-service.yml
+++ b/tasks/aws-vpce-service.yml
@@ -9,76 +9,67 @@
 
 - name: AWS | VPCe Services | Discovery Route tables IDs
   block:
+    - name: AWS | VPCe Services | Filter Route Tables
+      ec2_vpc_route_table_info:
+        region: "{{ item_vpc.region }}"
+        filters:
+          "tag:Name": "{{ item_rtb }}"
+      register: rtbs
+      with_items: "{{ item_vpces.route_tables | d([]) }}"
+      loop_control:
+        loop_var: item_rtb
 
-  - name: AWS | VPCe Services | Filter Route Tables
-    ec2_vpc_route_table_info:
-      region: "{{ item_vpc.region }}"
-      filters:
-        "tag:Name": "{{ item_rtb }}"
-    register: rtbs
-    with_items: "{{ item_vpces.route_tables | d([]) }}"
-    loop_control:
-      loop_var: item_rtb
-
-  - name: AWS | VPCe Services | Mount Rtb IDs
-    set_fact:
-      vpce_resources: "{{ vpce_resources |combine({
-          'rtb_ids': vpce_resources['rtb_ids']|d([]) + [item.route_tables[0].id]
-        }) }}"
-    with_items: "{{ rtbs.results }}"
-
+    - name: AWS | VPCe Services | Mount Rtb IDs
+      set_fact:
+        vpce_resources: "{{ vpce_resources |combine({
+            'rtb_ids': vpce_resources['rtb_ids']|d([]) +
+                       [item.route_tables[0].id]
+          }) }}"
+      with_items: "{{ rtbs.results }}"
   when: item_vpces.route_tables | d([]) | length > 0
 
 
 - name: AWS | VPCe Services | Discovery Security Groups IDs
   block:
+    - name: AWS | VPCe Services | Filter Security Groups
+      amazon.aws.ec2_group_info:
+        region: "{{ item_vpc.region }}"
+        filters:
+          group-name: "{{ item_sg }}"
+      register: sgs
+      with_items: "{{ item_vpces.security_group_names | d([]) }}"
+      loop_control:
+        loop_var: item_sg
 
-  - name: AWS | VPCe Services | Filter Security Groups
-    amazon.aws.ec2_group_info:
-      region: "{{ item_vpc.region }}"
-      filters:
-        group-name: "{{ item_sg }}"
-    register: sgs
-    with_items: "{{ item_vpces.security_group_names | d([]) }}"
-    loop_control:
-      loop_var: item_sg
-
-  - debug: var=sgs
-
-  - name: AWS | VPCe Services | Mount SG IDs
-    set_fact:
-      vpce_resources: "{{ vpce_resources |combine({
-          'sg_ids': vpce_resources['sg_ids']|d([]) + [item.security_groups[0].group_id]
-        }) }}"
-    with_items: "{{ sgs.results }}"
-
+    - name: AWS | VPCe Services | Mount SG IDs
+      set_fact:
+        vpce_resources: "{{ vpce_resources |combine({
+            'sg_ids': vpce_resources['sg_ids']|d([]) +
+                      [item.security_groups[0].group_id]
+          }) }}"
+      with_items: "{{ sgs.results }}"
   when: item_vpces.security_group_names | d([]) | length > 0
 
 - name: AWS | VPCe Services | Discovery Subnet IDs
   block:
+    - name: AWS | VPCe Services | Filter Subnets by Name
+      amazon.aws.ec2_vpc_subnet_info:
+        region: "{{ item_vpc.region }}"
+        filters:
+          "tag:Name": "{{ item_net }}"
+      register: nets
+      with_items: "{{ item_vpces.subnet_names | d([]) }}"
+      loop_control:
+        loop_var: item_net
 
-  - name: AWS | VPCe Services | Filter Subnets by Name
-    amazon.aws.ec2_vpc_subnet_info:
-      region: "{{ item_vpc.region }}"
-      filters:
-        "tag:Name": "{{ item_net }}"
-    register: nets
-    with_items: "{{ item_vpces.subnet_names | d([]) }}"
-    loop_control:
-      loop_var: item_net
-
-  - debug: var=nets
-
-  - name: AWS | VPCe Services | Mount Subnet IDs
-    set_fact:
-      vpce_resources: "{{ vpce_resources |combine({
-          'net_ids': vpce_resources['net_ids']|d([]) + [item.subnets[0].id]
-        }) }}"
-    with_items: "{{ nets.results }}"
-
+    - name: AWS | VPCe Services | Mount Subnet IDs
+      set_fact:
+        vpce_resources: "{{ vpce_resources |combine({
+            'net_ids': vpce_resources['net_ids']|d([]) +
+                       [item.subnets[0].id]
+          }) }}"
+      with_items: "{{ nets.results }}"
   when: item_vpces.subnet_names | d([]) | length > 0
-
-- debug: var=vpce_resources
 
 - name: AWS | VPCe Services | Create
   ec2_vpc_endpoint:

--- a/tasks/aws-vpce-service.yml
+++ b/tasks/aws-vpce-service.yml
@@ -1,14 +1,14 @@
 ---
-- name: AWS | VPCe Services | Init
+- name: AWS | VPCe Services | Debug VPCe
   debug:
-    msg: "Endpoint service name: {{ item_vpces.service }}"
+    var: item_vpces
 
-- name: AWS | VPCe Services | Lookup Route tables
+- name: AWS | VPCe Services | Init Locla Vars
+  set_fact:
+    vpce_resources: {}
+
+- name: AWS | VPCe Services | Discovery Route tables IDs
   block:
-
-  - name: AWS | VPCe Services | Init vars
-    set_fact:
-      vpces_rtb_ids: []
 
   - name: AWS | VPCe Services | Filter Route Tables
     ec2_vpc_route_table_info:
@@ -22,14 +22,63 @@
 
   - name: AWS | VPCe Services | Mount Rtb IDs
     set_fact:
-      vpces_rtb_ids: "{{ vpces_rtb_ids + [item.route_tables[0].id] }}"
+      vpce_resources: "{{ vpce_resources |combine({
+          'rtb_ids': vpce_resources['rtb_ids']|d([]) + [item.route_tables[0].id]
+        }) }}"
     with_items: "{{ rtbs.results }}"
 
-  - name: AWS | VPCe Services | Show table IDS
-    debug:
-      var: vpces_rtb_ids
-
   when: item_vpces.route_tables | d([]) | length > 0
+
+
+- name: AWS | VPCe Services | Discovery Security Groups IDs
+  block:
+
+  - name: AWS | VPCe Services | Filter Security Groups
+    amazon.aws.ec2_group_info:
+      region: "{{ item_vpc.region }}"
+      filters:
+        group-name: "{{ item_sg }}"
+    register: sgs
+    with_items: "{{ item_vpces.security_group_names | d([]) }}"
+    loop_control:
+      loop_var: item_sg
+
+  - debug: var=sgs
+
+  - name: AWS | VPCe Services | Mount SG IDs
+    set_fact:
+      vpce_resources: "{{ vpce_resources |combine({
+          'sg_ids': vpce_resources['sg_ids']|d([]) + [item.security_groups[0].group_id]
+        }) }}"
+    with_items: "{{ sgs.results }}"
+
+  when: item_vpces.security_group_names | d([]) | length > 0
+
+- name: AWS | VPCe Services | Discovery Subnet IDs
+  block:
+
+  - name: AWS | VPCe Services | Filter Subnets by Name
+    amazon.aws.ec2_vpc_subnet_info:
+      region: "{{ item_vpc.region }}"
+      filters:
+        "tag:Name": "{{ item_net }}"
+    register: nets
+    with_items: "{{ item_vpces.subnet_names | d([]) }}"
+    loop_control:
+      loop_var: item_net
+
+  - debug: var=nets
+
+  - name: AWS | VPCe Services | Mount Subnet IDs
+    set_fact:
+      vpce_resources: "{{ vpce_resources |combine({
+          'net_ids': vpce_resources['net_ids']|d([]) + [item.subnets[0].id]
+        }) }}"
+    with_items: "{{ nets.results }}"
+
+  when: item_vpces.subnet_names | d([]) | length > 0
+
+- debug: var=vpce_resources
 
 - name: AWS | VPCe Services | Create
   ec2_vpc_endpoint:
@@ -37,9 +86,9 @@
     region: "{{ item_vpc.region }}"
     vpc_id: "{{ vpc_id }}"
     service: "{{ item_vpces.service }}"
-    route_table_ids: "{{ vpces_rtb_ids | d(omit) }}"
-    vpc_endpoint_security_groups: "{{ item_vpces.security_groups | d(omit) }}"
-    vpc_endpoint_subnets: "{{ item_vpces.subnets | d(omit) }}"
+    route_table_ids: "{{ vpce_resources['rtb_ids'] | d(omit) }}"
+    vpc_endpoint_security_groups: "{{ vpce_resources['sg_ids'] | d(omit) }}"
+    vpc_endpoint_subnets: "{{ vpce_resources['net_ids'] | d(omit) }}"
     vpc_endpoint_type: "{{ item_vpces.type | d('Gateway') }}"
     validate_certs: "{{ item_vpces.validate_certs | d(omit) }}"
     policy_file: "{{ item_vpces.policy_file | d(omit) }}"


### PR DESCRIPTION
WIP

Supporting interface type endpoint services

```yaml
    endpoint_services:
      - name: ec2
        service: com.amazonaws.us-east-1.ec2
        type: Interface
        security_groups:
          - sg-0c7194ef21d902720
        subnets:
          - subnet-0835b3d0776d427ac
          - subnet-0da7c916d3de0f114
          - subnet-07f7d504ea50f16d5
```

ToDos:
- [x] Should discover SG by Name
- [x] Should discover Subnets by Name

Depends on https://github.com/mtulio/ansible-role-cloud-network/pull/10